### PR TITLE
chore(Renovate): 🔧  Add initial global setup

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"assigneesFromCodeOwners": true,
+	"baseBranches": ["main"],
+	"commitMessagePrefix": "chore(Renovate): {{#if isPin}}📌{{else if isRollback}}⬇️{{else if isReplacement}}🏗️{{else if (or isMajor isPatch isSingleVersion)}}⬆️{{/if}} ",
+	"commitMessageTopic": "dependency `{{depName}}`",
+	"commitMessageExtra": "to `v{{#if isMajor}}{{{newMajor}}}{{else}}{{#if isSingleVersion}}{{{newVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}`",
+	"dependencyDashboard": true,
+	"extends": ["config:base"],
+	"labels": ["🧩 dependencies"],
+	"reviewersFromCodeOwners": true,
+	"schedule": ["after 10pm and before 5am every weekday", "every sunday"],
+	"stabilityDays": 3,
+	"timezone": "Europe/Warsaw"
+}


### PR DESCRIPTION
# Purpose

Create an initial configuration for the [Renovate bot](https://docs.renovatebot.com/).

It will require it to be installed as GitHub app for **only selected repositories** _(it has a free plan for it)_, in our case - [adchitects/configs](https://github.com/adchitects/configs).

**The goal is to automate the maintenance workflow.**

---

@robert-adchitects 